### PR TITLE
Fix daytime grid charging + UX polish + debug export

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -39,6 +39,7 @@ battery_targets:
   daytime_reserve_start_hour: 8         # Start hour for daytime reserve window
   daytime_reserve_end_hour: 18          # End hour (exclusive) for reserve window
   overnight_charge_threshold_cents: 10  # Charge from grid if price < this (c/kWh)
+  force_charge_below_price_cents: 0     # Hard override: force grid charge when buy price <= this (c/kWh). 0 = disabled
 
 arbitrage:
   break_even_delta_cents: 5             # Minimum sell-buy spread to arbitrage (c/kWh)

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -31,11 +31,11 @@ planning:
   solver_timeout_seconds: 25
 
 battery_targets:
-  evening_soc_target: 0.90              # Target SOC before peak (soft)
+  evening_soc_target: 0.90              # Charging goal — planner aims for this SOC by evening_target_hour (soft)
   evening_target_hour: 16               # Hour to check evening target (4pm)
   morning_soc_minimum: 0.20             # Minimum SOC to hold overnight
   morning_minimum_hour: 6               # Hour to check morning minimum (6am)
-  daytime_reserve_soc_target: 0.50      # Target SOC to bias toward during daytime
+  daytime_reserve_soc_target: 0.50      # Minimum SOC floor during daytime window for backup readiness (NOT a charging target)
   daytime_reserve_start_hour: 8         # Start hour for daytime reserve window
   daytime_reserve_end_hour: 18          # End hour (exclusive) for reserve window
   overnight_charge_threshold_cents: 10  # Charge from grid if price < this (c/kWh)

--- a/src/power_master/config/schema.py
+++ b/src/power_master/config/schema.py
@@ -74,6 +74,9 @@ class BatteryTargetsConfig(BaseModel):
     daytime_reserve_start_hour: int = Field(8, ge=0, le=23)
     daytime_reserve_end_hour: int = Field(18, ge=0, le=24)
     overnight_charge_threshold_cents: int = 10
+    # Force grid charge whenever buy price is at or below this value (c/kWh).
+    # 0 disables the override and lets the solver decide normally.
+    force_charge_below_price_cents: float = Field(0.0, ge=0.0)
 
 
 class ArbitrageConfig(BaseModel):

--- a/src/power_master/dashboard/debug_export.py
+++ b/src/power_master/dashboard/debug_export.py
@@ -1,0 +1,106 @@
+"""Build a debug bundle: redacted config, current plan, last 24h data and logs."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from power_master.config.schema import AppConfig
+
+# Field names whose values are stripped from the exported config.
+_SECRET_KEYS = frozenset({
+    "api_key",
+    "api_token",
+    "bot_token",
+    "password",
+    "password_hash",
+    "session_secret",
+    "smtp_password",
+    "token",
+    "user_key",
+})
+
+
+def redact_config(config_dict: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of the config with any secret-looking keys masked.
+
+    A value is masked to "***REDACTED***" when non-empty, or left as "" so an
+    empty-vs-set distinction is still visible.  Webhook headers are replaced
+    wholesale since header names/values can both leak auth.
+    """
+    def _scrub(value: Any, parent_key: str | None = None) -> Any:
+        if isinstance(value, dict):
+            out = {}
+            for k, v in value.items():
+                if k in _SECRET_KEYS:
+                    out[k] = "***REDACTED***" if v not in ("", None) else v
+                elif k == "headers" and parent_key == "webhook":
+                    out[k] = {h: "***REDACTED***" for h in v} if v else v
+                else:
+                    out[k] = _scrub(v, k)
+            return out
+        if isinstance(value, list):
+            return [_scrub(item, parent_key) for item in value]
+        return value
+
+    return _scrub(config_dict)
+
+
+async def build_debug_bundle(
+    config: AppConfig,
+    repo: Any,
+    *,
+    hours: int = 24,
+    log_limit: int = 10000,
+    in_memory_logs: list[dict[str, Any]] | None = None,
+) -> bytes:
+    """Return a .zip archive of config, plan, telemetry, prices and logs."""
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=hours)
+    cutoff_iso = cutoff.isoformat()
+    end_iso = now.isoformat()
+
+    redacted = redact_config(config.model_dump(mode="python"))
+
+    plan = await repo.get_active_plan()
+    plan_slots = await repo.get_plan_slots(plan["id"]) if plan else []
+
+    telemetry = await repo.get_telemetry_since(cutoff_iso)
+    import_prices = await repo.get_historical("import_price_cents", cutoff_iso, end_iso)
+    export_prices = await repo.get_historical("export_price_cents", cutoff_iso, end_iso)
+    db_logs = await repo.get_logs_since(cutoff_iso, limit=log_limit)
+
+    meta = {
+        "generated_at": end_iso,
+        "hours": hours,
+        "record_counts": {
+            "plan_slots": len(plan_slots),
+            "telemetry": len(telemetry),
+            "import_prices": len(import_prices),
+            "export_prices": len(export_prices),
+            "db_logs": len(db_logs),
+            "in_memory_logs": len(in_memory_logs) if in_memory_logs else 0,
+        },
+    }
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("meta.json", _json(meta))
+        zf.writestr("config.json", _json(redacted))
+        zf.writestr("plan.json", _json({"plan": plan, "slots": plan_slots}))
+        zf.writestr("telemetry.json", _json(telemetry))
+        zf.writestr("prices.json", _json({
+            "import_price_cents": import_prices,
+            "export_price_cents": export_prices,
+        }))
+        zf.writestr("logs_db.json", _json(db_logs))
+        if in_memory_logs is not None:
+            zf.writestr("logs_memory.json", _json(in_memory_logs))
+    return buf.getvalue()
+
+
+def _json(obj: Any) -> str:
+    return json.dumps(obj, indent=2, default=str, sort_keys=True)

--- a/src/power_master/dashboard/routes/api.py
+++ b/src/power_master/dashboard/routes/api.py
@@ -1175,6 +1175,42 @@ async def export_plan_history(request: Request, hours: int = 24) -> Response:
     )
 
 
+@router.get("/debug/export")
+async def export_debug_bundle(request: Request, hours: int = 24) -> Response:
+    """Bundle redacted config, current plan, last N hours of data and logs as a .zip."""
+    from power_master.dashboard.debug_export import build_debug_bundle
+    from power_master.dashboard.log_buffer import log_buffer
+
+    denied = require_admin(request)
+    if denied:
+        return denied
+
+    hours = min(max(hours, 1), 168)
+    repo = request.app.state.repo
+    config = request.app.state.config
+
+    db_log_handler = getattr(request.app.state, "db_log_handler", None)
+    if db_log_handler is not None:
+        try:
+            await db_log_handler.flush_to_db()
+        except Exception:
+            pass
+
+    in_memory_logs = log_buffer.get_records(limit=10000)
+
+    payload = await build_debug_bundle(
+        config, repo, hours=hours, in_memory_logs=in_memory_logs,
+    )
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+    filename = f"power_master_debug_{timestamp}.zip"
+    return Response(
+        content=payload,
+        media_type="application/zip",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
 # ── Config ───────────────────────────────────────────
 
 @router.get("/config")

--- a/src/power_master/dashboard/routes/optimiser_lab.py
+++ b/src/power_master/dashboard/routes/optimiser_lab.py
@@ -16,6 +16,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from power_master.config.manager import ConfigManager
 from power_master.config.schema import AppConfig
 from power_master.dashboard.auth import require_admin
+from power_master.dashboard.routes.settings import PERCENTAGE_FIELDS
 from power_master.optimisation.backtest_lab import BacktestResult, run_backtest
 
 router = APIRouter()
@@ -80,11 +81,19 @@ def _parse_form_to_nested(form_data: dict[str, Any], allowed_keys: list[str]) ->
     for key in allowed_keys:
         if key not in form_data:
             continue
+        value = form_data[key]
+        # Percentage fields are sent as whole-number percents (0-100);
+        # the schema stores them as 0-1 fractions.
+        if key in PERCENTAGE_FIELDS and isinstance(value, str) and value != "":
+            try:
+                value = float(value) / 100.0
+            except ValueError:
+                pass
         parts = key.split(".")
         current = result
         for part in parts[:-1]:
             current = current.setdefault(part, {})
-        current[parts[-1]] = form_data[key]
+        current[parts[-1]] = value
     return result
 
 

--- a/src/power_master/dashboard/routes/settings.py
+++ b/src/power_master/dashboard/routes/settings.py
@@ -65,9 +65,24 @@ NULLABLE_FIELDS = {
     "providers.solar.azimuth",
 }
 
-# Fields displayed as percentage in UI but stored as 0-1 decimal
+# Fields displayed as percentage in UI but stored as 0-1 decimal.
+# The settings form always sends these as whole-number percents (0-100);
+# the route converts to the 0-1 fractions the schema/solver expect.
 PERCENTAGE_FIELDS = {
+    "battery.soc_min_hard",
+    "battery.soc_max_hard",
+    "battery.soc_min_soft",
+    "battery.soc_max_soft",
+    "battery.round_trip_efficiency",
+    "battery_targets.evening_soc_target",
+    "battery_targets.morning_soc_minimum",
+    "battery_targets.daytime_reserve_soc_target",
     "planning.soc_deviation_tolerance",
+    "anti_oscillation.hysteresis_band",
+    "arbitrage.price_dampen_factor",
+    "storm.reserve_soc_target",
+    "storm.probability_threshold",
+    "resilience.degraded_safety_margin",
     "notifications.battery_low_threshold",
     "notifications.battery_full_threshold",
 }

--- a/src/power_master/dashboard/static/app.css
+++ b/src/power_master/dashboard/static/app.css
@@ -817,6 +817,21 @@ tr.mode-4 { background: rgba(248, 81, 73, 0.03); }
     width: auto;
     margin-right: 8px;
 }
+.form-group .input-unit {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 400px;
+}
+.form-group .input-unit input[type="number"] {
+    flex: 1;
+    max-width: none;
+}
+.form-group .input-unit .unit-label {
+    color: var(--text-muted);
+    font-size: 14px;
+    font-weight: 500;
+}
 
 /* ── Buttons ────────────────────────────────────── */
 

--- a/src/power_master/dashboard/templates/optimiser_lab.html
+++ b/src/power_master/dashboard/templates/optimiser_lab.html
@@ -182,7 +182,10 @@
         <div class="settings-grid">
             <div class="form-group">
                 <label for="battery_targets.evening_soc_target">Evening SOC Target</label>
-                <input type="number" step="0.01" min="0" max="1" id="battery_targets.evening_soc_target" name="battery_targets.evening_soc_target" value="{{ config.battery_targets.evening_soc_target }}">
+                <div class="input-unit">
+                    <input type="number" step="1" min="0" max="100" id="battery_targets.evening_soc_target" name="battery_targets.evening_soc_target" value="{{ (config.battery_targets.evening_soc_target * 100)|round(0)|int }}">
+                    <span class="unit-label">%</span>
+                </div>
             </div>
             <div class="form-group">
                 <label for="battery_targets.evening_target_hour">Evening Hour</label>
@@ -190,7 +193,10 @@
             </div>
             <div class="form-group">
                 <label for="battery_targets.morning_soc_minimum">Morning SOC Minimum</label>
-                <input type="number" step="0.01" min="0" max="1" id="battery_targets.morning_soc_minimum" name="battery_targets.morning_soc_minimum" value="{{ config.battery_targets.morning_soc_minimum }}">
+                <div class="input-unit">
+                    <input type="number" step="1" min="0" max="100" id="battery_targets.morning_soc_minimum" name="battery_targets.morning_soc_minimum" value="{{ (config.battery_targets.morning_soc_minimum * 100)|round(0)|int }}">
+                    <span class="unit-label">%</span>
+                </div>
             </div>
             <div class="form-group">
                 <label for="battery_targets.morning_minimum_hour">Morning Hour</label>
@@ -198,7 +204,10 @@
             </div>
             <div class="form-group">
                 <label for="battery_targets.daytime_reserve_soc_target">Daytime Reserve SOC</label>
-                <input type="number" step="0.01" min="0" max="1" id="battery_targets.daytime_reserve_soc_target" name="battery_targets.daytime_reserve_soc_target" value="{{ config.battery_targets.daytime_reserve_soc_target }}">
+                <div class="input-unit">
+                    <input type="number" step="1" min="0" max="100" id="battery_targets.daytime_reserve_soc_target" name="battery_targets.daytime_reserve_soc_target" value="{{ (config.battery_targets.daytime_reserve_soc_target * 100)|round(0)|int }}">
+                    <span class="unit-label">%</span>
+                </div>
             </div>
             <div class="form-group">
                 <label for="battery_targets.daytime_reserve_start_hour">Daytime Start Hour</label>
@@ -235,7 +244,10 @@
             </div>
             <div class="form-group">
                 <label for="arbitrage.price_dampen_factor">Dampen Factor</label>
-                <input type="number" step="0.05" min="0" max="1" id="arbitrage.price_dampen_factor" name="arbitrage.price_dampen_factor" value="{{ config.arbitrage.price_dampen_factor }}">
+                <div class="input-unit">
+                    <input type="number" step="1" min="0" max="100" id="arbitrage.price_dampen_factor" name="arbitrage.price_dampen_factor" value="{{ (config.arbitrage.price_dampen_factor * 100)|round(0)|int }}">
+                    <span class="unit-label">%</span>
+                </div>
             </div>
             <div class="form-group">
                 <label for="fixed_costs.hedging_per_kwh_cents">Hedging (c/kWh)</label>

--- a/src/power_master/dashboard/templates/settings.html
+++ b/src/power_master/dashboard/templates/settings.html
@@ -174,29 +174,47 @@
     </div>
     <div class="form-group">
         <label for="battery.soc_min_hard">SOC Min Hard</label>
-        <input type="number" id="battery.soc_min_hard" name="battery.soc_min_hard" step="0.01" value="{{ config.battery.soc_min_hard }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery.soc_min_hard" name="battery.soc_min_hard" step="1" value="{{ (config.battery.soc_min_hard * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="battery.soc_max_hard">SOC Max Hard</label>
-        <input type="number" id="battery.soc_max_hard" name="battery.soc_max_hard" step="0.01" value="{{ config.battery.soc_max_hard }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery.soc_max_hard" name="battery.soc_max_hard" step="1" value="{{ (config.battery.soc_max_hard * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="battery.soc_min_soft">SOC Min Soft</label>
-        <input type="number" id="battery.soc_min_soft" name="battery.soc_min_soft" step="0.01" value="{{ config.battery.soc_min_soft }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery.soc_min_soft" name="battery.soc_min_soft" step="1" value="{{ (config.battery.soc_min_soft * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="battery.soc_max_soft">SOC Max Soft</label>
-        <input type="number" id="battery.soc_max_soft" name="battery.soc_max_soft" step="0.01" value="{{ config.battery.soc_max_soft }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery.soc_max_soft" name="battery.soc_max_soft" step="1" value="{{ (config.battery.soc_max_soft * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="battery.round_trip_efficiency">Round Trip Efficiency</label>
-        <input type="number" id="battery.round_trip_efficiency" name="battery.round_trip_efficiency" step="0.01" value="{{ config.battery.round_trip_efficiency }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery.round_trip_efficiency" name="battery.round_trip_efficiency" step="1" value="{{ (config.battery.round_trip_efficiency * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
 
     <h2>Battery Targets</h2>
     <div class="form-group">
         <label for="battery_targets.evening_soc_target">Evening SOC Target</label>
-        <input type="number" id="battery_targets.evening_soc_target" name="battery_targets.evening_soc_target" step="0.01" value="{{ config.battery_targets.evening_soc_target }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery_targets.evening_soc_target" name="battery_targets.evening_soc_target" step="1" value="{{ (config.battery_targets.evening_soc_target * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="battery_targets.evening_target_hour">Evening Target Hour (0-23)</label>
@@ -204,7 +222,10 @@
     </div>
     <div class="form-group">
         <label for="battery_targets.morning_soc_minimum">Morning SOC Minimum</label>
-        <input type="number" id="battery_targets.morning_soc_minimum" name="battery_targets.morning_soc_minimum" step="0.01" value="{{ config.battery_targets.morning_soc_minimum }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery_targets.morning_soc_minimum" name="battery_targets.morning_soc_minimum" step="1" value="{{ (config.battery_targets.morning_soc_minimum * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="battery_targets.morning_minimum_hour">Morning Minimum Hour (0-23)</label>
@@ -213,7 +234,10 @@
     <h3>Daytime Reserve</h3>
     <div class="form-group">
         <label for="battery_targets.daytime_reserve_soc_target">Daytime Reserve SOC Target</label>
-        <input type="number" id="battery_targets.daytime_reserve_soc_target" name="battery_targets.daytime_reserve_soc_target" step="0.01" value="{{ config.battery_targets.daytime_reserve_soc_target }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="battery_targets.daytime_reserve_soc_target" name="battery_targets.daytime_reserve_soc_target" step="1" value="{{ (config.battery_targets.daytime_reserve_soc_target * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
         <small class="form-hint">Soft daytime SOC bias for backup readiness (0 disables).</small>
     </div>
     <div class="form-group">
@@ -272,12 +296,18 @@
         <input type="number" id="planning.periodic_rebuild_interval_seconds" name="planning.periodic_rebuild_interval_seconds" value="{{ config.planning.periodic_rebuild_interval_seconds }}">
     </div>
     <div class="form-group">
-        <label for="planning.forecast_delta_threshold_pct">Forecast Delta Threshold (%)</label>
-        <input type="number" id="planning.forecast_delta_threshold_pct" name="planning.forecast_delta_threshold_pct" step="0.1" value="{{ config.planning.forecast_delta_threshold_pct }}">
+        <label for="planning.forecast_delta_threshold_pct">Forecast Delta Threshold</label>
+        <div class="input-unit">
+            <input type="number" id="planning.forecast_delta_threshold_pct" name="planning.forecast_delta_threshold_pct" step="0.1" value="{{ config.planning.forecast_delta_threshold_pct }}">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
-        <label for="planning.soc_deviation_tolerance">SOC Deviation Tolerance (%)</label>
-        <input type="number" id="planning.soc_deviation_tolerance" name="planning.soc_deviation_tolerance" step="1" value="{{ (config.planning.soc_deviation_tolerance * 100)|round(0)|int }}" min="1" max="20">
+        <label for="planning.soc_deviation_tolerance">SOC Deviation Tolerance</label>
+        <div class="input-unit">
+            <input type="number" id="planning.soc_deviation_tolerance" name="planning.soc_deviation_tolerance" step="1" value="{{ (config.planning.soc_deviation_tolerance * 100)|round(0)|int }}" min="1" max="20">
+            <span class="unit-label">%</span>
+        </div>
         <small>Replan when actual SOC deviates from plan by this percentage</small>
     </div>
     <div class="form-group">
@@ -325,8 +355,11 @@
         <small class="form-hint">Import prices above this are dampened to reduce solver overreaction.</small>
     </div>
     <div class="form-group">
-        <label for="arbitrage.price_dampen_factor">Dampen Factor (0-1)</label>
-        <input type="number" id="arbitrage.price_dampen_factor" name="arbitrage.price_dampen_factor" step="0.1" min="0" max="1" value="{{ config.arbitrage.price_dampen_factor }}">
+        <label for="arbitrage.price_dampen_factor">Dampen Factor</label>
+        <div class="input-unit">
+            <input type="number" id="arbitrage.price_dampen_factor" name="arbitrage.price_dampen_factor" step="1" min="0" max="100" value="{{ (config.arbitrage.price_dampen_factor * 100)|round(0)|int }}">
+            <span class="unit-label">%</span>
+        </div>
         <small class="form-hint">Fraction of excess above threshold to keep. Applied progressively by horizon: near-term less damped, far-term more damped.</small>
     </div>
 
@@ -749,7 +782,10 @@
     </div>
     <div class="form-group">
         <label for="anti_oscillation.hysteresis_band">Hysteresis Band</label>
-        <input type="number" id="anti_oscillation.hysteresis_band" name="anti_oscillation.hysteresis_band" step="0.01" value="{{ config.anti_oscillation.hysteresis_band }}" min="0" max="0.5">
+        <div class="input-unit">
+            <input type="number" id="anti_oscillation.hysteresis_band" name="anti_oscillation.hysteresis_band" step="1" value="{{ (config.anti_oscillation.hysteresis_band * 100)|round(0)|int }}" min="0" max="50">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="anti_oscillation.rate_limit_window_seconds">Rate Limit Window (s)</label>
@@ -772,11 +808,17 @@
     </div>
     <div class="form-group">
         <label for="storm.reserve_soc_target">Reserve SOC Target</label>
-        <input type="number" id="storm.reserve_soc_target" name="storm.reserve_soc_target" step="0.01" value="{{ config.storm.reserve_soc_target }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="storm.reserve_soc_target" name="storm.reserve_soc_target" step="1" value="{{ (config.storm.reserve_soc_target * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="storm.probability_threshold">Probability Threshold</label>
-        <input type="number" id="storm.probability_threshold" name="storm.probability_threshold" step="0.01" value="{{ config.storm.probability_threshold }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="storm.probability_threshold" name="storm.probability_threshold" step="1" value="{{ (config.storm.probability_threshold * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="storm.horizon_hours">Horizon (hours)</label>
@@ -801,7 +843,10 @@
     </div>
     <div class="form-group">
         <label for="resilience.degraded_safety_margin">Degraded Safety Margin</label>
-        <input type="number" id="resilience.degraded_safety_margin" name="resilience.degraded_safety_margin" step="0.01" value="{{ config.resilience.degraded_safety_margin }}" min="0" max="1">
+        <div class="input-unit">
+            <input type="number" id="resilience.degraded_safety_margin" name="resilience.degraded_safety_margin" step="1" value="{{ (config.resilience.degraded_safety_margin * 100)|round(0)|int }}" min="0" max="100">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label for="resilience.stale_telemetry_max_age_seconds">Stale Telemetry Max Age (s)</label>
@@ -984,12 +1029,18 @@
 
     <h3>Event Rules</h3>
     <div class="form-group">
-        <label>Battery Low Threshold (%)</label>
-        <input type="number" name="notifications.battery_low_threshold" value="{{ (config.notifications.battery_low_threshold * 100)|int }}" min="0" max="100" step="1">
+        <label>Battery Low Threshold</label>
+        <div class="input-unit">
+            <input type="number" name="notifications.battery_low_threshold" value="{{ (config.notifications.battery_low_threshold * 100)|int }}" min="0" max="100" step="1">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
-        <label>Battery Full Threshold (%)</label>
-        <input type="number" name="notifications.battery_full_threshold" value="{{ (config.notifications.battery_full_threshold * 100)|int }}" min="0" max="100" step="1">
+        <label>Battery Full Threshold</label>
+        <div class="input-unit">
+            <input type="number" name="notifications.battery_full_threshold" value="{{ (config.notifications.battery_full_threshold * 100)|int }}" min="0" max="100" step="1">
+            <span class="unit-label">%</span>
+        </div>
     </div>
     <div class="form-group">
         <label>Log Forwarding Min Level</label>

--- a/src/power_master/dashboard/templates/settings.html
+++ b/src/power_master/dashboard/templates/settings.html
@@ -215,6 +215,7 @@
             <input type="number" id="battery_targets.evening_soc_target" name="battery_targets.evening_soc_target" step="1" value="{{ (config.battery_targets.evening_soc_target * 100)|round(0)|int }}" min="0" max="100">
             <span class="unit-label">%</span>
         </div>
+        <small class="form-hint">Charging goal: the planner aims to reach this SOC by Evening Target Hour, pulling from cheap daytime slots (grid or solar) as needed.</small>
     </div>
     <div class="form-group">
         <label for="battery_targets.evening_target_hour">Evening Target Hour (0-23)</label>
@@ -233,12 +234,12 @@
     </div>
     <h3>Daytime Reserve</h3>
     <div class="form-group">
-        <label for="battery_targets.daytime_reserve_soc_target">Daytime Reserve SOC Target</label>
+        <label for="battery_targets.daytime_reserve_soc_target">Daytime Reserve SOC Floor</label>
         <div class="input-unit">
             <input type="number" id="battery_targets.daytime_reserve_soc_target" name="battery_targets.daytime_reserve_soc_target" step="1" value="{{ (config.battery_targets.daytime_reserve_soc_target * 100)|round(0)|int }}" min="0" max="100">
             <span class="unit-label">%</span>
         </div>
-        <small class="form-hint">Soft daytime SOC bias for backup readiness (0 disables).</small>
+        <small class="form-hint">Minimum SOC to hold during the daytime window for backup readiness — <strong>not</strong> the charging target. The Evening SOC Target is what the planner charges toward. Set to 0 to disable.</small>
     </div>
     <div class="form-group">
         <label for="battery_targets.daytime_reserve_start_hour">Daytime Reserve Start Hour (0-23)</label>

--- a/src/power_master/dashboard/templates/settings.html
+++ b/src/power_master/dashboard/templates/settings.html
@@ -1170,6 +1170,18 @@
         GitHub Container Registry, restarts the container, and verifies health. If the update
         fails, the previous version continues running and the error is shown above.
     </p>
+
+    <h2 style="margin-top: 32px;">Debug Export</h2>
+    <p style="font-size: 0.85em; color: var(--text-muted);">
+        Bundle redacted config, the current plan, telemetry, price history and logs into a single
+        zip for debugging. API keys, passwords and session tokens are stripped before download.
+    </p>
+    <div style="display: flex; gap: 8px; align-items: center; margin-top: 8px;">
+        <label for="debug-export-hours" style="font-size: 13px;">Hours of history</label>
+        <input type="number" id="debug-export-hours" value="24" min="1" max="168" style="width: 80px; padding: 4px 8px;">
+        <button type="button" class="btn btn-primary" onclick="downloadDebugBundle()">Download Debug Bundle</button>
+        <span id="debug-export-status" style="font-size: 12px; color: var(--text-muted);"></span>
+    </div>
 </section>
 
 </form>
@@ -1428,6 +1440,34 @@ function refreshSystemInfo() {
         }
     })
     .catch(function() {});
+}
+
+function downloadDebugBundle() {
+    var hours = document.getElementById('debug-export-hours').value || '24';
+    var status = document.getElementById('debug-export-status');
+    status.textContent = 'Building bundle…';
+    fetch('/api/debug/export?hours=' + encodeURIComponent(hours))
+    .then(function(r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        var disposition = r.headers.get('Content-Disposition') || '';
+        var match = disposition.match(/filename=([^;]+)/);
+        var filename = match ? match[1].trim() : 'power_master_debug.zip';
+        return r.blob().then(function(blob) { return { blob: blob, filename: filename }; });
+    })
+    .then(function(res) {
+        var url = URL.createObjectURL(res.blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = res.filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        status.textContent = 'Downloaded ' + res.filename;
+    })
+    .catch(function(err) {
+        status.textContent = 'Failed: ' + err.message;
+    });
 }
 
 function checkForUpdate() {

--- a/src/power_master/optimisation/solver.py
+++ b/src/power_master/optimisation/solver.py
@@ -246,6 +246,8 @@ def solve(
     if inputs.storm_active:
         active_constraints.append("storm_reserve")
 
+    force_charge_threshold = config.battery_targets.force_charge_below_price_cents
+
     for t in range(n):
         charge_val = pulp.value(charge[t]) or 0
         discharge_val = pulp.value(discharge[t]) or 0
@@ -259,6 +261,18 @@ def solve(
             solar_w=float(inputs.solar_forecast_w[t]),
             load_w=float(inputs.load_forecast_w[t]),
         )
+        # Cheap-price override: force grid charging whenever buy price is at or
+        # below the configured threshold, regardless of solver decision.  Skip
+        # during spikes (prices are high, so this is a no-op in practice, but
+        # the guard makes the intent explicit).
+        price_cents = float(inputs.import_rate_cents[t])
+        if (
+            force_charge_threshold > 0
+            and price_cents <= force_charge_threshold
+            and not inputs.is_spike[t]
+            and soc_val < config.battery.soc_max_soft
+        ):
+            mode = SlotMode.FORCE_CHARGE
         power = _determine_target_power(
             mode=mode,
             discharge_w=discharge_val,

--- a/src/power_master/optimisation/solver.py
+++ b/src/power_master/optimisation/solver.py
@@ -258,8 +258,6 @@ def solve(
         import_val = pulp.value(grid_import[t]) or 0
         mode = _determine_mode(
             charge_val, discharge_val, export_val, import_val, inputs.is_spike[t],
-            solar_w=float(inputs.solar_forecast_w[t]),
-            load_w=float(inputs.load_forecast_w[t]),
         )
         # Cheap-price override: force grid charging whenever buy price is at or
         # below the configured threshold, regardless of solver decision.
@@ -336,7 +334,6 @@ def _resolve_planner_timezone(config: AppConfig):
 
 def _determine_mode(
     charge_w: float, discharge_w: float, grid_export_w: float, grid_import_w: float, is_spike: bool,
-    solar_w: float = 0.0, load_w: float = 0.0,
 ) -> SlotMode:
     """Determine the operating mode from solver decision variables.
 
@@ -348,10 +345,6 @@ def _determine_mode(
     threshold = 50  # Minimum power to consider active
 
     if charge_w > threshold and grid_import_w > threshold:
-        # If excess solar covers the load, the battery can charge from the
-        # surplus in SELF_USE mode — no need to force-charge from the grid.
-        if solar_w > load_w + threshold:
-            return SlotMode.SELF_USE
         return SlotMode.FORCE_CHARGE
     elif discharge_w > threshold and grid_export_w > threshold:
         # Arbitrage: actively exporting to grid for profit

--- a/src/power_master/optimisation/solver.py
+++ b/src/power_master/optimisation/solver.py
@@ -262,15 +262,10 @@ def solve(
             load_w=float(inputs.load_forecast_w[t]),
         )
         # Cheap-price override: force grid charging whenever buy price is at or
-        # below the configured threshold, regardless of solver decision.  Skip
-        # during spikes (prices are high, so this is a no-op in practice, but
-        # the guard makes the intent explicit).
-        price_cents = float(inputs.import_rate_cents[t])
+        # below the configured threshold, regardless of solver decision.
         if (
             force_charge_threshold > 0
-            and price_cents <= force_charge_threshold
-            and not inputs.is_spike[t]
-            and soc_val < config.battery.soc_max_soft
+            and float(inputs.import_rate_cents[t]) <= force_charge_threshold
         ):
             mode = SlotMode.FORCE_CHARGE
         power = _determine_target_power(

--- a/tests/test_dashboard/test_dashboard.py
+++ b/tests/test_dashboard/test_dashboard.py
@@ -449,6 +449,62 @@ class TestAPI:
         assert "arbitrage" in data
 
 
+class TestDebugExport:
+    @pytest.mark.asyncio
+    async def test_debug_export_returns_zip(self, client, repo) -> None:
+        import io
+        import json
+        import zipfile
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        await repo.store_telemetry(
+            soc=0.42, battery_power_w=0, solar_power_w=0, grid_power_w=0,
+            load_power_w=0,
+        )
+        await repo.store_historical(
+            "import_price_cents", 9.5, "amber",
+            (now - timedelta(hours=2)).isoformat(),
+        )
+
+        resp = await client.get("/api/debug/export?hours=6")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/zip"
+        assert "power_master_debug_" in resp.headers["content-disposition"]
+
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            names = set(zf.namelist())
+            assert {"meta.json", "config.json", "plan.json",
+                    "telemetry.json", "prices.json", "logs_db.json"} <= names
+            meta = json.loads(zf.read("meta.json"))
+            assert meta["hours"] == 6
+            assert meta["record_counts"]["telemetry"] >= 1
+            assert meta["record_counts"]["import_prices"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_debug_export_redacts_secrets(self, client, repo, settings_config_manager) -> None:
+        import io
+        import json
+        import zipfile
+
+        cfg = settings_config_manager.config
+        cfg.providers.tariff.api_key = "psk_supersecret"
+        cfg.mqtt.password = "broker-secret"
+        cfg.notifications.channels.telegram.bot_token = "tg-token"
+
+        resp = await client.get("/api/debug/export?hours=1")
+        assert resp.status_code == 200
+
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            config_json = json.loads(zf.read("config.json"))
+
+        assert config_json["providers"]["tariff"]["api_key"] == "***REDACTED***"
+        assert config_json["mqtt"]["password"] == "***REDACTED***"
+        assert config_json["notifications"]["channels"]["telegram"]["bot_token"] == "***REDACTED***"
+        # non-secret fields survive
+        assert "capacity_wh" in config_json["battery"]
+
+
 class TestLoadDetailAndOverride:
     """Tests for load detail and manual override endpoints."""
 

--- a/tests/test_dashboard/test_dashboard.py
+++ b/tests/test_dashboard/test_dashboard.py
@@ -95,9 +95,10 @@ class TestSettingsPage:
         resp = await client.get("/settings")
         # Default battery capacity
         assert "10000" in resp.text
-        # Default SOC hard limits
-        assert "0.05" in resp.text
-        assert "0.95" in resp.text
+        # Default SOC hard limits rendered as whole-number percents with % unit
+        assert 'value="5"' in resp.text
+        assert 'value="95"' in resp.text
+        assert '<span class="unit-label">%</span>' in resp.text
 
 
 class TestSettingsPost:
@@ -167,10 +168,11 @@ class TestSettingsPost:
 
     @pytest.mark.asyncio
     async def test_save_daytime_reserve_settings(self, client) -> None:
+        # SOC target is posted as a whole-number percent (55 -> 0.55).
         await client.post(
             "/settings",
             data={
-                "battery_targets.daytime_reserve_soc_target": "0.55",
+                "battery_targets.daytime_reserve_soc_target": "55",
                 "battery_targets.daytime_reserve_start_hour": "9",
                 "battery_targets.daytime_reserve_end_hour": "17",
             },
@@ -210,10 +212,11 @@ class TestSettingsPost:
     @pytest.mark.asyncio
     async def test_save_checkbox_unchecked(self, client) -> None:
         """POST without checkbox sets False."""
-        # Don't send storm.enabled — simulates unchecked checkbox
+        # Don't send storm.enabled — simulates unchecked checkbox.
+        # Reserve SOC target is posted as a whole-number percent (90 -> 0.90).
         await client.post(
             "/settings",
-            data={"storm.reserve_soc_target": "0.90"},
+            data={"storm.reserve_soc_target": "90"},
             follow_redirects=False,
         )
         resp = await client.get("/api/config")

--- a/tests/test_optimisation/test_solver.py
+++ b/tests/test_optimisation/test_solver.py
@@ -297,6 +297,63 @@ class TestSolverBasic:
         assert daytime_soc, "Expected daytime slots in plan"
         assert max(daytime_soc) >= 0.48
 
+    def test_grid_charges_when_solar_covers_load_but_cannot_fill_battery(self) -> None:
+        """Planner must still grid-charge during cheap slots when modest solar
+        covers the load but can't fill the battery before peak.
+
+        Regression: a previous bug in _determine_mode flipped FORCE_CHARGE slots
+        to SELF_USE whenever current-slot solar exceeded current-slot load,
+        which defeated daytime-reserve and evening targets whenever any solar
+        was present during cheap periods.
+        """
+        config = AppConfig()
+        config.load_profile.timezone = "UTC"
+        config.battery_targets.evening_soc_target = 0.90
+        config.battery_targets.evening_target_hour = 18
+
+        n = 48
+        start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        starts = [start + timedelta(minutes=30 * i) for i in range(n)]
+
+        solar = []
+        load = []
+        import_prices = []
+        for i in range(n):
+            hour = starts[i].hour
+            # Modest solar 9-15h: covers load but not enough to fill the battery
+            solar.append(1500.0 if 9 <= hour < 15 else 0.0)
+            load.append(1000.0)
+            # Cheap daytime 10-14h, expensive evening peak 18-21h
+            if 10 <= hour < 14:
+                import_prices.append(3.0)
+            elif 18 <= hour < 21:
+                import_prices.append(60.0)
+            else:
+                import_prices.append(25.0)
+
+        inputs = SolverInputs(
+            solar_forecast_w=solar,
+            load_forecast_w=load,
+            import_rate_cents=import_prices,
+            export_rate_cents=[5.0] * n,
+            is_spike=[False] * n,
+            current_soc=0.15,
+            wacb_cents=10.0,
+            slot_start_times=starts,
+        )
+
+        plan = solve(config, inputs)
+
+        cheap_daytime_slots = [
+            slot for slot in plan.slots
+            if 10 <= slot.start.hour < 14
+        ]
+        force_charge = [s for s in cheap_daytime_slots if s.mode == SlotMode.FORCE_CHARGE]
+        assert force_charge, (
+            "Expected FORCE_CHARGE during cheap daytime slots even though "
+            f"solar covers load; got modes {[s.mode for s in cheap_daytime_slots]}"
+        )
+
 
     def test_evening_soc_target_triggers_charging(self) -> None:
         """Even with flat pricing, evening SOC target should force charging."""

--- a/tests/test_optimisation/test_solver.py
+++ b/tests/test_optimisation/test_solver.py
@@ -84,6 +84,48 @@ class TestSolverBasic:
         max_soc = max(s.expected_soc for s in plan.slots)
         assert max_soc > 0.1, f"SOC should rise above initial 0.1, max was {max_soc}"
 
+    def test_force_charge_below_price_override(self) -> None:
+        """When buy price is at/below the override threshold, plan must FORCE_CHARGE.
+
+        Even with abundant solar (which would normally put the slot in SELF_USE),
+        the override should kick in so the battery gets topped up from grid.
+        """
+        config = AppConfig()
+        config.battery_targets.force_charge_below_price_cents = 3.0
+        inputs = _make_inputs(
+            n_slots=4,
+            solar=4000.0,   # Solar covers load — would normally be SELF_USE
+            load=1000.0,
+            import_price=2.0,  # Below the 3c threshold
+            export_price=1.0,
+            soc=0.4,
+        )
+        plan = solve(config, inputs)
+
+        force_charge = [s for s in plan.slots if s.mode == SlotMode.FORCE_CHARGE]
+        assert len(force_charge) == len(plan.slots), (
+            f"Expected every slot to be FORCE_CHARGE when price is below threshold, "
+            f"got {[s.mode for s in plan.slots]}"
+        )
+        for slot in force_charge:
+            assert slot.target_power_w > 0
+
+    def test_force_charge_override_disabled_by_default(self) -> None:
+        """With the override at 0 (disabled), cheap-price slots follow solver logic."""
+        config = AppConfig()
+        assert config.battery_targets.force_charge_below_price_cents == 0.0
+        inputs = _make_inputs(
+            n_slots=4,
+            solar=4000.0,
+            load=1000.0,
+            import_price=2.0,
+            export_price=1.0,
+            soc=0.9,  # Already full — solver has no reason to force-charge
+        )
+        plan = solve(config, inputs)
+        force_charge = [s for s in plan.slots if s.mode == SlotMode.FORCE_CHARGE]
+        assert len(force_charge) == 0
+
     def test_high_export_triggers_force_discharge(self) -> None:
         """When export price is high (above WACB + break-even), should force discharge for arbitrage."""
         config = AppConfig()

--- a/tests/test_optimisation/test_solver.py
+++ b/tests/test_optimisation/test_solver.py
@@ -120,7 +120,7 @@ class TestSolverBasic:
             load=1000.0,
             import_price=2.0,
             export_price=1.0,
-            soc=0.9,  # Already full — solver has no reason to force-charge
+            soc=0.9,
         )
         plan = solve(config, inputs)
         force_charge = [s for s in plan.slots if s.mode == SlotMode.FORCE_CHARGE]


### PR DESCRIPTION
## Summary

- **Fix the "battery stuck at 50-60% on cheap days" bug.** `_determine_mode` was flipping solver-planned `FORCE_CHARGE` slots to `SELF_USE` whenever current-slot solar happened to exceed current-slot load, throwing away the MILP's horizon-wide optimisation. Now the solver's charge/import decisions are honoured as-is.
- **New cheap-price override.** `battery_targets.force_charge_below_price_cents` (0 = disabled) forces grid charging whenever the buy price is at or below the configured threshold.
- **Standardised percentage settings.** SOC bounds, evening/morning/daytime targets, round-trip efficiency, hysteresis band, dampen factor, probability threshold and degraded safety margin are all now rendered as whole-number percents (0–100) with a visible `%` next to the field. Same treatment applied to the optimiser-lab form.
- **Clarified SOC target labels and hints.** Evening target is explicitly called out as the charging goal; the former "Daytime Reserve SOC Target" is renamed to "Daytime Reserve SOC Floor" with a hint that it's a minimum hold, not a charging target.
- **Debug export.** New admin-only `GET /api/debug/export` endpoint and "Download Debug Bundle" button in Settings → System. Returns a zip with redacted config, current plan, last N hours (default 24, max 168) of telemetry + price history, DB-backed logs and the in-memory log buffer.

## Test plan
- [x] `pytest tests/test_optimisation/test_solver.py` — 22 passed incl. new `test_grid_charges_when_solar_covers_load_but_cannot_fill_battery` and `test_force_charge_below_price_override` regressions
- [x] `pytest tests/test_dashboard/` — 49 passed, incl. new `TestDebugExport` (zip structure + secret redaction)
- [x] Full suite — 442 passed, 3 pre-existing unrelated load-scheduler failures on `main`
- [ ] Smoke test in running dashboard: toggle `force_charge_below_price_cents`, verify plan shows `FORCE_CHARGE` during cheap slots
- [ ] Smoke test: download debug bundle, confirm api_key / passwords / tokens are redacted in `config.json`
- [ ] Deploy to Pi and confirm on a cheap-day afternoon the battery climbs past 50% toward the 90% evening target

https://claude.ai/code/session_01GJctMFFu3Z3cjuvrhc6dVM