### PR TITLE
Force-charge UI input + solar forecast calibration

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -78,6 +78,12 @@ providers:
     kwp: 5.0                           # Installed PV size in kWp
     timezone: "Australia/Brisbane"
     update_interval_seconds: 21600      # 6 hours
+    # Off by default — enable once enough telemetry has accumulated (~1 week).
+    # When enabled, the planner uses a ridge-regression correction fitted on
+    # recent forecast-vs-actual pairs.  Raw forecast is still logged.
+    calibration_enabled: false
+    calibration_window_days: 21
+    calibration_refit_interval_seconds: 3600
 
   storm:
     type: "bom"

--- a/src/power_master/config/schema.py
+++ b/src/power_master/config/schema.py
@@ -130,6 +130,11 @@ class SolarProviderConfig(BaseModel):
     update_interval_seconds: int = 21600
     validity_seconds: int = 21600
     system_size_kw: float = 0.0  # 0 = no fallback; set to PV size for bell curve fallback
+    # Solar forecast calibration — fits a small ridge regression against recent
+    # telemetry to correct systematic provider bias before the planner consumes it.
+    calibration_enabled: bool = False
+    calibration_window_days: int = Field(21, ge=3, le=90)
+    calibration_refit_interval_seconds: int = Field(3600, ge=60)
 
 
 class StormProviderConfig(BaseModel):

--- a/src/power_master/dashboard/debug_export.py
+++ b/src/power_master/dashboard/debug_export.py
@@ -56,6 +56,7 @@ async def build_debug_bundle(
     hours: int = 24,
     log_limit: int = 10000,
     in_memory_logs: list[dict[str, Any]] | None = None,
+    solar_calibration: dict[str, Any] | None = None,
 ) -> bytes:
     """Return a .zip archive of config, plan, telemetry, prices and logs."""
     now = datetime.now(timezone.utc)
@@ -99,6 +100,8 @@ async def build_debug_bundle(
         zf.writestr("logs_db.json", _json(db_logs))
         if in_memory_logs is not None:
             zf.writestr("logs_memory.json", _json(in_memory_logs))
+        if solar_calibration is not None:
+            zf.writestr("solar_calibration.json", _json(solar_calibration))
     return buf.getvalue()
 
 

--- a/src/power_master/dashboard/routes/api.py
+++ b/src/power_master/dashboard/routes/api.py
@@ -1175,6 +1175,25 @@ async def export_plan_history(request: Request, hours: int = 24) -> Response:
     )
 
 
+@router.get("/forecast/calibration")
+async def forecast_calibration(request: Request) -> dict:
+    """Inspect the current solar-forecast calibration model."""
+    application = getattr(request.app.state, "application", None)
+    if application is None:
+        return {"enabled": False, "status": "application_not_available"}
+    config = request.app.state.config
+    solar_cfg = config.providers.solar
+    model = getattr(application, "_solar_calibration_model", None)
+    last_fit = getattr(application, "_solar_calibration_last_fit", None)
+    return {
+        "enabled": bool(solar_cfg.calibration_enabled),
+        "window_days": solar_cfg.calibration_window_days,
+        "refit_interval_seconds": solar_cfg.calibration_refit_interval_seconds,
+        "last_fit": last_fit.isoformat() if last_fit else None,
+        "model": model.as_dict() if model is not None else None,
+    }
+
+
 @router.get("/debug/export")
 async def export_debug_bundle(request: Request, hours: int = 24) -> Response:
     """Bundle redacted config, current plan, last N hours of data and logs as a .zip."""
@@ -1198,8 +1217,20 @@ async def export_debug_bundle(request: Request, hours: int = 24) -> Response:
 
     in_memory_logs = log_buffer.get_records(limit=10000)
 
+    application = getattr(request.app.state, "application", None)
+    solar_calibration = None
+    if application is not None:
+        model = getattr(application, "_solar_calibration_model", None)
+        last_fit = getattr(application, "_solar_calibration_last_fit", None)
+        solar_calibration = {
+            "enabled": bool(config.providers.solar.calibration_enabled),
+            "last_fit": last_fit.isoformat() if last_fit else None,
+            "model": model.as_dict() if model is not None else None,
+        }
+
     payload = await build_debug_bundle(
         config, repo, hours=hours, in_memory_logs=in_memory_logs,
+        solar_calibration=solar_calibration,
     )
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")

--- a/src/power_master/dashboard/routes/settings.py
+++ b/src/power_master/dashboard/routes/settings.py
@@ -34,6 +34,7 @@ def _parse_form_to_config(form_data: dict[str, str]) -> dict[str, Any]:
 # All checkbox field paths — these are sent as "on" if checked, absent if unchecked
 CHECKBOX_FIELDS = {
     "planning.optimiser_enabled",
+    "providers.solar.calibration_enabled",
     "storm.enabled",
     "mqtt.enabled",
     "mqtt.ha_discovery_enabled",

--- a/src/power_master/dashboard/templates/settings.html
+++ b/src/power_master/dashboard/templates/settings.html
@@ -507,6 +507,32 @@
         <label for="providers.solar.validity_seconds">Forecast Validity (s)</label>
         <input type="number" id="providers.solar.validity_seconds" name="providers.solar.validity_seconds" value="{{ config.providers.solar.validity_seconds }}">
     </div>
+    <h3 style="margin-top:12px;">Forecast Calibration</h3>
+    <small class="form-hint" style="display:block; margin-bottom:8px;">
+        Fits a small ridge regression against recent telemetry to correct provider bias.
+        The planner uses the calibrated forecast. Raw forecast is still logged. Coefficients and MAE lift
+        are visible at <a href="/api/forecast/calibration" target="_blank">/api/forecast/calibration</a>.
+    </small>
+    <div class="form-group">
+        <label for="providers.solar.calibration_enabled">
+            <input type="checkbox" id="providers.solar.calibration_enabled" name="providers.solar.calibration_enabled" {% if config.providers.solar.calibration_enabled %}checked{% endif %}>
+            Enable Calibration
+        </label>
+    </div>
+    <div class="form-group">
+        <label for="providers.solar.calibration_window_days">Training Window</label>
+        <div class="input-unit">
+            <input type="number" id="providers.solar.calibration_window_days" name="providers.solar.calibration_window_days" min="3" max="90" value="{{ config.providers.solar.calibration_window_days }}">
+            <span class="unit-label">days</span>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="providers.solar.calibration_refit_interval_seconds">Refit Interval</label>
+        <div class="input-unit">
+            <input type="number" id="providers.solar.calibration_refit_interval_seconds" name="providers.solar.calibration_refit_interval_seconds" min="60" value="{{ config.providers.solar.calibration_refit_interval_seconds }}">
+            <span class="unit-label">s</span>
+        </div>
+    </div>
     <h2>Weather (Open-Meteo)</h2>
     <div class="provider-status" id="provider-status-weather_forecast">
         <span class="provider-status-dot"></span>

--- a/src/power_master/dashboard/templates/settings.html
+++ b/src/power_master/dashboard/templates/settings.html
@@ -250,8 +250,19 @@
         <input type="number" id="battery_targets.daytime_reserve_end_hour" name="battery_targets.daytime_reserve_end_hour" value="{{ config.battery_targets.daytime_reserve_end_hour }}" min="1" max="24">
     </div>
     <div class="form-group">
-        <label for="battery_targets.overnight_charge_threshold_cents">Overnight Charge Threshold (c/kWh)</label>
-        <input type="number" id="battery_targets.overnight_charge_threshold_cents" name="battery_targets.overnight_charge_threshold_cents" value="{{ config.battery_targets.overnight_charge_threshold_cents }}">
+        <label for="battery_targets.overnight_charge_threshold_cents">Overnight Charge Threshold</label>
+        <div class="input-unit">
+            <input type="number" id="battery_targets.overnight_charge_threshold_cents" name="battery_targets.overnight_charge_threshold_cents" value="{{ config.battery_targets.overnight_charge_threshold_cents }}">
+            <span class="unit-label">c/kWh</span>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="battery_targets.force_charge_below_price_cents">Force Grid Charge Below Price</label>
+        <div class="input-unit">
+            <input type="number" id="battery_targets.force_charge_below_price_cents" name="battery_targets.force_charge_below_price_cents" step="0.1" min="0" value="{{ config.battery_targets.force_charge_below_price_cents }}">
+            <span class="unit-label">c/kWh</span>
+        </div>
+        <small class="form-hint">Hard override: whenever the buy price is at or below this, the plan forces grid charging regardless of solver decision. Set to 0 to disable.</small>
     </div>
 
     <h2>Battery Cost Basis Reset</h2>

--- a/src/power_master/db/repository.py
+++ b/src/power_master/db/repository.py
@@ -114,6 +114,19 @@ class Repository:
             row = await cursor.fetchone()
             return dict(row) if row else None
 
+    async def get_forecasts_between(
+        self, provider_type: str, start_iso: str, end_iso: str,
+    ) -> list[dict[str, Any]]:
+        """Return forecast snapshots fetched in the given window."""
+        async with self.db.execute(
+            """SELECT * FROM forecast_snapshots
+               WHERE provider_type = ? AND fetched_at >= ? AND fetched_at <= ?
+               ORDER BY fetched_at""",
+            (provider_type, start_iso, end_iso),
+        ) as cursor:
+            rows = await cursor.fetchall()
+            return [dict(r) for r in rows]
+
     # ── Tariff Schedules ────────────────────────────────────
 
     async def store_tariff(

--- a/src/power_master/forecast/solar_calibration.py
+++ b/src/power_master/forecast/solar_calibration.py
@@ -1,0 +1,306 @@
+"""Solar forecast calibration.
+
+Fits a small ridge regression mapping raw provider forecast + time-of-day
+features to observed telemetry, so the planner sees a calibrated forecast
+rather than taking the provider's output verbatim.
+
+Features (4): [1, forecast/peak, sin(2π·h/24), cos(2π·h/24)] where h is
+local solar hour.  Targets: actual/peak.  EWMA-weighted samples with a
+5-day half-life by default.  Training pairs only the "0–3h ahead" horizon
+band from stored forecast snapshots with the telemetry recorded in the
+matching slot, to avoid blending nowcast bias with long-horizon weather
+miss.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from power_master.timezone_utils import resolve_timezone
+
+logger = logging.getLogger(__name__)
+
+# Keep paired samples within this horizon band (snapshot.fetched_at to slot.start)
+NEAR_TERM_HORIZON_HOURS = 3.0
+
+# Ridge regression regularisation (prevents coefficient blow-up on collinear features)
+RIDGE_LAMBDA = 1e-3
+
+# Minimum samples before the model will engage; below this, apply_calibration passes through
+MIN_TRAINING_SAMPLES = 50
+
+N_FEATURES = 4  # intercept, forecast_norm, sin(h), cos(h)
+
+
+@dataclass
+class TrainingSample:
+    slot_start_utc: datetime
+    local_solar_hour: float  # 0.0–24.0
+    forecast_w: float
+    actual_w: float
+    age_days: float  # slot_start relative to training time (for EWMA weighting)
+
+
+@dataclass
+class CalibrationModel:
+    coefficients: list[float]  # length N_FEATURES
+    n_samples: int
+    trained_at: datetime
+    system_peak_w: float
+    raw_mae_w: float  # mean absolute error of raw forecast on training set
+    calibrated_mae_w: float  # mean absolute error of calibrated forecast on training set
+    tz_name: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "coefficients": self.coefficients,
+            "n_samples": self.n_samples,
+            "trained_at": self.trained_at.isoformat(),
+            "system_peak_w": self.system_peak_w,
+            "raw_mae_w": round(self.raw_mae_w, 1),
+            "calibrated_mae_w": round(self.calibrated_mae_w, 1),
+            "tz_name": self.tz_name,
+            "lift_w": round(self.raw_mae_w - self.calibrated_mae_w, 1),
+        }
+
+
+def _features(forecast_w: float, local_solar_hour: float, system_peak_w: float) -> list[float]:
+    f_norm = forecast_w / system_peak_w if system_peak_w > 0 else 0.0
+    angle = 2.0 * math.pi * local_solar_hour / 24.0
+    return [1.0, f_norm, math.sin(angle), math.cos(angle)]
+
+
+def _predict_norm(features: list[float], coef: list[float]) -> float:
+    return sum(f * c for f, c in zip(features, coef))
+
+
+def _local_solar_hour(t_utc: datetime, tz_name: str) -> float:
+    tz = resolve_timezone(tz_name)
+    local = t_utc.astimezone(tz)
+    return local.hour + local.minute / 60.0
+
+
+# ── Linear algebra helpers (stdlib ridge solve for a 4×4 system) ─────
+
+def _solve_ridge(
+    x_rows: list[list[float]],
+    y: list[float],
+    weights: list[float],
+    ridge_lambda: float,
+) -> list[float]:
+    """Weighted ridge regression via normal equations.
+
+    Solves (X^T W X + λI) β = X^T W y using Gauss-Jordan elimination.
+    k is small (4) so the stdlib implementation is plenty fast.
+    """
+    k = len(x_rows[0])
+    # Build k×k matrix A = X^T W X + λI and k-vector b = X^T W y
+    a = [[0.0] * k for _ in range(k)]
+    b = [0.0] * k
+    for row, target, w in zip(x_rows, y, weights):
+        for i in range(k):
+            b[i] += w * row[i] * target
+            for j in range(k):
+                a[i][j] += w * row[i] * row[j]
+    for i in range(k):
+        a[i][i] += ridge_lambda
+
+    # Augment [A | b] and eliminate
+    aug = [a[i] + [b[i]] for i in range(k)]
+    for pivot in range(k):
+        # Partial pivoting for numerical stability
+        max_row = max(range(pivot, k), key=lambda r: abs(aug[r][pivot]))
+        if abs(aug[max_row][pivot]) < 1e-12:
+            # Singular — should not happen after ridge, but be defensive
+            raise ValueError("Calibration: singular matrix after ridge regularisation")
+        aug[pivot], aug[max_row] = aug[max_row], aug[pivot]
+        pivot_val = aug[pivot][pivot]
+        for j in range(pivot, k + 1):
+            aug[pivot][j] /= pivot_val
+        for r in range(k):
+            if r != pivot and aug[r][pivot] != 0.0:
+                factor = aug[r][pivot]
+                for j in range(pivot, k + 1):
+                    aug[r][j] -= factor * aug[pivot][j]
+    return [row[k] for row in aug]
+
+
+# ── Training set construction ────────────────────────────────────────
+
+async def build_training_set(
+    repo: Any,
+    *,
+    window_days: int,
+    system_peak_w: float,
+    tz_name: str,
+    reference_time: datetime | None = None,
+) -> list[TrainingSample]:
+    """Pair historical forecast snapshots with telemetry.
+
+    Only near-term horizon pairs are kept (slot start within 3h of snapshot
+    fetched_at).  Forecast samples below max(100W, 5 % of system peak) are
+    rejected so near-zero divisions don't pollute the regression.
+    """
+    if system_peak_w <= 0:
+        return []
+
+    now = reference_time or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=window_days)
+    min_forecast_w = max(100.0, 0.05 * system_peak_w)
+
+    snapshots = await repo.get_forecasts_between(
+        "solar", cutoff.isoformat(), now.isoformat(),
+    )
+    if not snapshots:
+        return []
+
+    telemetry = await repo.get_telemetry_since(cutoff.isoformat())
+    if not telemetry:
+        return []
+
+    # Bucket telemetry by 30-minute slot start for fast lookup
+    telemetry_by_slot: dict[str, list[float]] = {}
+    for row in telemetry:
+        ts = _parse_iso(row["recorded_at"])
+        if ts is None:
+            continue
+        slot_key = _slot_key(ts)
+        telemetry_by_slot.setdefault(slot_key, []).append(float(row["solar_power_w"]))
+
+    samples: list[TrainingSample] = []
+    for snap in snapshots:
+        fetched_at = _parse_iso(snap["fetched_at"])
+        if fetched_at is None:
+            continue
+        estimate_json = snap.get("solar_estimate_json")
+        if not estimate_json:
+            continue
+        try:
+            slots = json.loads(estimate_json)
+        except (TypeError, ValueError):
+            continue
+        for slot in slots:
+            slot_start = _parse_iso(slot.get("start") or slot.get("period_end"))
+            if slot_start is None:
+                continue
+            horizon_hours = (slot_start - fetched_at).total_seconds() / 3600.0
+            if horizon_hours < 0 or horizon_hours > NEAR_TERM_HORIZON_HOURS:
+                continue
+            forecast_w = float(slot.get("pv_estimate_w") or 0.0)
+            if forecast_w < min_forecast_w:
+                continue
+            actuals = telemetry_by_slot.get(_slot_key(slot_start))
+            if not actuals:
+                continue
+            actual_w = sum(actuals) / len(actuals)
+            age_days = (now - slot_start).total_seconds() / 86400.0
+            samples.append(TrainingSample(
+                slot_start_utc=slot_start,
+                local_solar_hour=_local_solar_hour(slot_start, tz_name),
+                forecast_w=forecast_w,
+                actual_w=max(0.0, actual_w),
+                age_days=max(0.0, age_days),
+            ))
+    return samples
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _slot_key(t: datetime) -> str:
+    """Round to the 30-minute slot start UTC, as a lookup key."""
+    minute = 30 * (t.minute // 30)
+    return t.replace(minute=minute, second=0, microsecond=0).isoformat()
+
+
+# ── Fit ──────────────────────────────────────────────────────────────
+
+def fit_calibration_model(
+    samples: list[TrainingSample],
+    *,
+    system_peak_w: float,
+    tz_name: str,
+    ewma_half_life_days: float = 5.0,
+    ridge_lambda: float = RIDGE_LAMBDA,
+    trained_at: datetime | None = None,
+) -> CalibrationModel | None:
+    """Fit a ridge regression on weighted, normalised samples."""
+    if len(samples) < MIN_TRAINING_SAMPLES or system_peak_w <= 0:
+        return None
+
+    decay = math.log(2.0) / max(ewma_half_life_days, 0.1)
+    x_rows: list[list[float]] = []
+    y: list[float] = []
+    weights: list[float] = []
+    for s in samples:
+        x_rows.append(_features(s.forecast_w, s.local_solar_hour, system_peak_w))
+        y.append(s.actual_w / system_peak_w)
+        weights.append(math.exp(-decay * s.age_days))
+
+    try:
+        coef = _solve_ridge(x_rows, y, weights, ridge_lambda)
+    except ValueError:
+        return None
+
+    # Compute training-set MAE for raw forecast and calibrated forecast (in watts)
+    raw_err = 0.0
+    cal_err = 0.0
+    total_w = 0.0
+    for row, target_norm, w, s in zip(x_rows, y, weights, samples):
+        raw_err += w * abs(s.forecast_w - s.actual_w)
+        cal_w = max(0.0, _predict_norm(row, coef)) * system_peak_w
+        cal_w = min(cal_w, 1.2 * system_peak_w)
+        cal_err += w * abs(cal_w - s.actual_w)
+        total_w += w
+    raw_mae = raw_err / total_w if total_w > 0 else 0.0
+    cal_mae = cal_err / total_w if total_w > 0 else 0.0
+
+    return CalibrationModel(
+        coefficients=coef,
+        n_samples=len(samples),
+        trained_at=trained_at or datetime.now(timezone.utc),
+        system_peak_w=system_peak_w,
+        raw_mae_w=raw_mae,
+        calibrated_mae_w=cal_mae,
+        tz_name=tz_name,
+    )
+
+
+# ── Apply ────────────────────────────────────────────────────────────
+
+def apply_calibration(
+    forecast_w: list[float],
+    slot_start_times: list[datetime],
+    model: CalibrationModel | None,
+) -> list[float]:
+    """Return calibrated forecast per slot.  Pass-through if model is None."""
+    if model is None:
+        return list(forecast_w)
+    peak = model.system_peak_w
+    ceiling = 1.2 * peak
+    out: list[float] = []
+    for f_w, t in zip(forecast_w, slot_start_times):
+        h = _local_solar_hour(t, model.tz_name)
+        features = _features(f_w, h, peak)
+        pred_norm = _predict_norm(features, model.coefficients)
+        pred_w = max(0.0, pred_norm * peak)
+        pred_w = min(pred_w, ceiling)
+        # Never invent solar at night — if raw forecast is zero, leave it zero
+        if f_w <= 0.0:
+            pred_w = 0.0
+        out.append(pred_w)
+    return out

--- a/src/power_master/main.py
+++ b/src/power_master/main.py
@@ -51,6 +51,10 @@ class Application:
         self._load_manager = None
         self._repo = None
 
+        # Solar calibration model (lazy-fitted, refreshed on stale)
+        self._solar_calibration_model = None
+        self._solar_calibration_last_fit = None
+
     async def start(self) -> None:
         """Start all application components in dependency order."""
         logger.info("Starting Power Master v%s", VERSION)
@@ -1237,6 +1241,25 @@ class Application:
                 solar_source.provider if solar_source else "None",
             )
 
+        # Calibrate the solar forecast against recent telemetry.  Model is
+        # refit lazily (see _refresh_solar_calibration).  When disabled or
+        # there's insufficient data, apply_calibration returns the raw
+        # forecast unchanged.
+        solar_model = await self._refresh_solar_calibration(repo)
+        if solar_model is not None:
+            from power_master.forecast.solar_calibration import apply_calibration
+            calibrated = apply_calibration(solar_forecast_w, slot_start_times, solar_model)
+            raw_sum = sum(solar_forecast_w)
+            cal_sum = sum(calibrated)
+            logger.info(
+                "Solar calibration applied: raw_total=%.0fWh cal_total=%.0fWh "
+                "n_samples=%d raw_mae=%.0fW cal_mae=%.0fW",
+                raw_sum * 0.5, cal_sum * 0.5,
+                solar_model.n_samples,
+                solar_model.raw_mae_w, solar_model.calibrated_mae_w,
+            )
+            solar_forecast_w = calibrated
+
         # Load forecast — use historic patterns, fall back to configured profile
         load_forecast_w = await self._build_load_forecast(
             repo, slot_start_times, n_slots,
@@ -1364,6 +1387,66 @@ class Application:
         )
 
         return plan
+
+    async def _refresh_solar_calibration(self, repo):
+        """Fit (or refit) the solar calibration model.  Returns None when disabled
+        or when insufficient training data is available.
+        """
+        solar_cfg = self.config.providers.solar
+        if not solar_cfg.calibration_enabled:
+            return None
+
+        peak_w = solar_cfg.system_size_kw * 1000.0 if solar_cfg.system_size_kw > 0 else solar_cfg.kwp * 1000.0
+        if peak_w <= 0:
+            return None
+
+        now = datetime.now(timezone.utc)
+        last_fit = self._solar_calibration_last_fit
+        refit_interval = timedelta(seconds=solar_cfg.calibration_refit_interval_seconds)
+        if self._solar_calibration_model is not None and last_fit is not None:
+            if now - last_fit < refit_interval:
+                return self._solar_calibration_model
+
+        from power_master.forecast.solar_calibration import (
+            build_training_set,
+            fit_calibration_model,
+        )
+
+        try:
+            samples = await build_training_set(
+                repo,
+                window_days=solar_cfg.calibration_window_days,
+                system_peak_w=peak_w,
+                tz_name=solar_cfg.timezone,
+                reference_time=now,
+            )
+            model = fit_calibration_model(
+                samples,
+                system_peak_w=peak_w,
+                tz_name=solar_cfg.timezone,
+                trained_at=now,
+            )
+        except Exception:
+            logger.exception("Solar calibration fit failed — using raw forecast")
+            self._solar_calibration_last_fit = now
+            return self._solar_calibration_model  # keep previous (possibly None)
+
+        self._solar_calibration_last_fit = now
+        if model is None:
+            logger.info(
+                "Solar calibration: insufficient data (%d samples, need >=50)",
+                len(samples),
+            )
+            self._solar_calibration_model = None
+            return None
+
+        self._solar_calibration_model = model
+        logger.info(
+            "Solar calibration refit: n=%d raw_mae=%.0fW cal_mae=%.0fW lift=%.0fW",
+            model.n_samples, model.raw_mae_w, model.calibrated_mae_w,
+            model.raw_mae_w - model.calibrated_mae_w,
+        )
+        return model
 
     async def _build_load_forecast(
         self,

--- a/tests/test_dashboard/test_dashboard.py
+++ b/tests/test_dashboard/test_dashboard.py
@@ -449,6 +449,33 @@ class TestAPI:
         assert "arbitrage" in data
 
 
+class TestForecastCalibrationAPI:
+    @pytest.mark.asyncio
+    async def test_returns_status_when_no_application(self, client) -> None:
+        resp = await client.get("/api/forecast/calibration")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_reports_no_model_when_enabled_but_untrained(
+        self, client, settings_config_manager,
+    ) -> None:
+        # Attach a minimal stub application with calibration enabled but no model.
+        class _StubApp:
+            _solar_calibration_model = None
+            _solar_calibration_last_fit = None
+
+        settings_config_manager.config.providers.solar.calibration_enabled = True
+        client._transport.app.state.application = _StubApp()
+        resp = await client.get("/api/forecast/calibration")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["model"] is None
+        assert "window_days" in data
+
+
 class TestDebugExport:
     @pytest.mark.asyncio
     async def test_debug_export_returns_zip(self, client, repo) -> None:

--- a/tests/test_forecast/test_solar_calibration.py
+++ b/tests/test_forecast/test_solar_calibration.py
@@ -1,0 +1,221 @@
+"""Tests for solar forecast calibration."""
+
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from power_master.forecast.solar_calibration import (
+    MIN_TRAINING_SAMPLES,
+    TrainingSample,
+    apply_calibration,
+    build_training_set,
+    fit_calibration_model,
+)
+
+
+def _sample(forecast_w: float, actual_w: float, local_hour: float, age_days: float = 0.5) -> TrainingSample:
+    return TrainingSample(
+        slot_start_utc=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        local_solar_hour=local_hour,
+        forecast_w=forecast_w,
+        actual_w=actual_w,
+        age_days=age_days,
+    )
+
+
+class TestFitCalibration:
+    def test_returns_none_when_too_few_samples(self) -> None:
+        samples = [_sample(1000.0, 1000.0, 12.0) for _ in range(10)]
+        model = fit_calibration_model(samples, system_peak_w=5000.0, tz_name="UTC")
+        assert model is None
+
+    def test_perfect_forecast_fits_with_near_zero_mae(self) -> None:
+        # When forecast matches actual perfectly, the fitted model should
+        # reproduce it (allowing for ridge shrinkage to split attribution
+        # between correlated features — forecast magnitude and time-of-day
+        # harmonics both describe the same bell curve).
+        samples = []
+        for i in range(MIN_TRAINING_SAMPLES + 20):
+            hour = 6.0 + (i % 12) * 0.5
+            forecast = 4000.0 * math.sin(math.pi * (hour - 6.0) / 12.0)
+            samples.append(_sample(forecast, forecast, hour))
+        model = fit_calibration_model(samples, system_peak_w=5000.0, tz_name="UTC")
+        assert model is not None
+        assert model.calibrated_mae_w < 30.0
+        assert model.raw_mae_w < 1e-6  # raw forecast was perfect
+        # Calibrated predictions don't wander far from raw:
+        times = [datetime(2025, 1, 1, int(h), int((h % 1) * 60), tzinfo=timezone.utc)
+                 for h in (6.0, 9.0, 12.0, 15.0)]
+        forecasts = [4000.0 * math.sin(math.pi * (h - 6.0) / 12.0)
+                     for h in (6.0, 9.0, 12.0, 15.0)]
+        # Fake UTC local: tz="UTC" so local hour matches the datetime hour
+        calibrated = apply_calibration(forecasts, times, model)
+        for raw, cal in zip(forecasts, calibrated):
+            if raw > 100:
+                assert abs(cal - raw) / raw < 0.05
+
+    def test_systematically_biased_forecast_reduces_mae(self) -> None:
+        # Forecast consistently 40% too high.  After calibration the MAE
+        # against actuals should fall dramatically.
+        samples = []
+        for i in range(MIN_TRAINING_SAMPLES * 2):
+            hour = 8.0 + (i % 10) * 0.5
+            true_w = 3500.0 * math.sin(math.pi * (hour - 8.0) / 10.0) + 200.0
+            forecast_w = true_w / 0.7
+            samples.append(_sample(forecast_w, true_w, hour))
+        model = fit_calibration_model(samples, system_peak_w=5000.0, tz_name="UTC")
+        assert model is not None
+        assert model.calibrated_mae_w < model.raw_mae_w * 0.1
+        # Applied to an in-distribution slot, the calibrated value should
+        # come in close to the actual.
+        hour = 10.5
+        true_w = 3500.0 * math.sin(math.pi * (hour - 8.0) / 10.0) + 200.0
+        forecast_w = true_w / 0.7
+        t = datetime(2025, 1, 1, int(hour), int((hour % 1) * 60), tzinfo=timezone.utc)
+        calibrated = apply_calibration([forecast_w], [t], model)
+        assert abs(calibrated[0] - true_w) / true_w < 0.05
+
+
+class TestApplyCalibration:
+    def test_passthrough_when_model_is_none(self) -> None:
+        forecasts = [100.0, 500.0, 2000.0, 0.0]
+        times = [datetime(2025, 1, 1, h, tzinfo=timezone.utc) for h in (6, 10, 12, 20)]
+        out = apply_calibration(forecasts, times, None)
+        assert out == forecasts
+
+    def test_never_invents_solar_at_night(self) -> None:
+        samples = [_sample(3000.0, 2100.0, 12.0) for _ in range(MIN_TRAINING_SAMPLES * 2)]
+        model = fit_calibration_model(samples, system_peak_w=5000.0, tz_name="UTC")
+        assert model is not None
+        # raw forecast zero → calibrated must remain zero
+        times = [datetime(2025, 1, 1, 2, tzinfo=timezone.utc)]
+        out = apply_calibration([0.0], times, model)
+        assert out == [0.0]
+
+    def test_respects_ceiling(self) -> None:
+        # Train on over-optimistic samples so the model predicts > peak
+        samples = []
+        for i in range(MIN_TRAINING_SAMPLES * 2):
+            hour = 11.0 + (i % 4) * 0.25
+            # Force model to predict > peak: teach it that large forecasts
+            # correspond to even larger actuals capped by telemetry.
+            forecast_w = 2000.0
+            samples.append(_sample(forecast_w, 6000.0, hour))
+        model = fit_calibration_model(samples, system_peak_w=5000.0, tz_name="UTC")
+        assert model is not None
+        times = [datetime(2025, 1, 1, 11, tzinfo=timezone.utc)]
+        out = apply_calibration([2000.0], times, model)
+        assert out[0] <= 1.2 * 5000.0 + 1e-6
+
+
+class TestTimezoneBucketing:
+    def test_local_solar_hour_respects_tz(self) -> None:
+        from power_master.forecast.solar_calibration import _local_solar_hour
+
+        # 22:00 UTC on 15 Jan is 09:00 AEDT (UTC+11)
+        t = datetime(2025, 1, 15, 22, 0, tzinfo=timezone.utc)
+        h = _local_solar_hour(t, "Australia/Brisbane")
+        # Brisbane is UTC+10 year-round → 08:00 local
+        assert abs(h - 8.0) < 0.01
+
+
+class TestBuildTrainingSet:
+    @pytest.mark.asyncio
+    async def test_pairs_near_term_forecast_with_telemetry(self, repo) -> None:
+        now = datetime(2025, 6, 15, 12, 0, tzinfo=timezone.utc)
+        system_peak = 5000.0
+
+        # Store a forecast snapshot with 6 near-term slots
+        fetched = now - timedelta(hours=1)
+        slots = []
+        for i in range(6):
+            slot_start = fetched + timedelta(minutes=30 * (i + 1))
+            slots.append({
+                "start": slot_start.isoformat(),
+                "end": (slot_start + timedelta(minutes=30)).isoformat(),
+                "pv_estimate_w": 2000.0 + i * 100,
+            })
+
+        await repo.db.execute(
+            """INSERT INTO forecast_snapshots
+               (provider_type, provider_name, fetched_at, horizon_start, horizon_end,
+                data_json, solar_estimate_json, confidence_score, storm_probability,
+                storm_window_start, storm_window_end, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "solar", "test", fetched.isoformat(),
+                slots[0]["start"], slots[-1]["end"],
+                "{}", json.dumps(slots), None, None, None, None, "ok",
+            ),
+        )
+        # Store actual telemetry at each slot start
+        for i, slot in enumerate(slots):
+            slot_start = datetime.fromisoformat(slot["start"])
+            actual = slot["pv_estimate_w"] * 0.6
+            await repo.db.execute(
+                """INSERT INTO telemetry
+                   (recorded_at, soc, battery_power_w, solar_power_w, grid_power_w,
+                    load_power_w, battery_voltage, battery_temp_c, inverter_mode,
+                    grid_available, raw_data_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    slot_start.isoformat(), 0.5, 0, int(actual), 0, 0,
+                    None, None, None, 1, None,
+                ),
+            )
+        await repo.db.commit()
+
+        samples = await build_training_set(
+            repo, window_days=30,
+            system_peak_w=system_peak, tz_name="UTC",
+            reference_time=now,
+        )
+        assert len(samples) == 6
+        for s in samples:
+            # actual ≈ 0.6 × forecast
+            assert abs(s.actual_w / s.forecast_w - 0.6) < 0.05
+
+    @pytest.mark.asyncio
+    async def test_rejects_samples_below_min_forecast(self, repo) -> None:
+        now = datetime(2025, 6, 15, 12, 0, tzinfo=timezone.utc)
+        fetched = now - timedelta(hours=1)
+        # Sub-floor forecast (50W) — should be rejected; min is max(100W, 5% of peak)
+        slot_start = fetched + timedelta(minutes=30)
+        slots = [{
+            "start": slot_start.isoformat(),
+            "end": (slot_start + timedelta(minutes=30)).isoformat(),
+            "pv_estimate_w": 50.0,
+        }]
+        await repo.db.execute(
+            """INSERT INTO forecast_snapshots
+               (provider_type, provider_name, fetched_at, horizon_start, horizon_end,
+                data_json, solar_estimate_json, confidence_score, storm_probability,
+                storm_window_start, storm_window_end, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "solar", "test", fetched.isoformat(),
+                slot_start.isoformat(),
+                (slot_start + timedelta(minutes=30)).isoformat(),
+                "{}", json.dumps(slots), None, None, None, None, "ok",
+            ),
+        )
+        await repo.db.execute(
+            """INSERT INTO telemetry
+               (recorded_at, soc, battery_power_w, solar_power_w, grid_power_w,
+                load_power_w, battery_voltage, battery_temp_c, inverter_mode,
+                grid_available, raw_data_json)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (slot_start.isoformat(), 0.5, 0, 400, 0, 0, None, None, None, 1, None),
+        )
+        await repo.db.commit()
+
+        samples = await build_training_set(
+            repo, window_days=30,
+            system_peak_w=5000.0, tz_name="UTC",
+            reference_time=now,
+        )
+        assert samples == []


### PR DESCRIPTION
Follow-up to #4 with two commits that landed on the branch after the merge.

## Summary

- **Force Grid Charge UI input (`655ccc1`)** — the `force_charge_below_price_cents` backend setting from #4 had no form field; users had to hand-edit `config.yaml` to use the override. Adds the input under Settings → Battery Targets and also standardises Overnight Charge Threshold to the same inline `c/kWh` unit pattern.
- **Solar forecast calibration (`1b6b5c0`)** — opt-in ridge regression that learns systematic provider bias from recent telemetry and corrects the forecast before the planner consumes it.
  - Features: `[1, forecast/peak, sin(2π·h/24), cos(2π·h/24)]` with local solar hour (tz-aware)
  - Training: forecast-snapshot ↔ telemetry pairs in the 0–3h ahead horizon band, EWMA-weighted (5-day half-life), 21-day window default
  - Stdlib Gauss-Jordan 4×4 solve — no numpy dependency
  - Requires ≥50 samples before engaging; rejects forecast < max(100W, 5% of system peak); clamps to `[0, 1.2 × peak]`; never invents night solar
  - Disabled by default — flip `providers.solar.calibration_enabled` on once users have accumulated ~1 week of history
  - Observability: `GET /api/forecast/calibration`, settings UI toggle, included in debug bundle

## Test plan
- [x] `pytest tests/test_forecast/test_solar_calibration.py` — 9 passed (fit invariants, timezone bucketing, training-set builder)
- [x] `pytest tests/` — 455 passed, 3 pre-existing unrelated load-scheduler failures
- [ ] Deploy, leave calibration off for ~1 week while telemetry accumulates
- [ ] Enable `providers.solar.calibration_enabled` and inspect `/api/forecast/calibration` to confirm `lift_w > 0`
- [ ] Confirm Force Grid Charge Below Price input appears in Settings → Battery Targets

https://claude.ai/code/session_01GJctMFFu3Z3cjuvrhc6dVM